### PR TITLE
fix: allow the user to bypass the default IPv6 endpoint

### DIFF
--- a/SimpleWebSocketServer.cpp
+++ b/SimpleWebSocketServer.cpp
@@ -181,7 +181,7 @@ void SimpleWebSocketServer::initServer()
 	{
 		ioService = std::make_shared<asio::io_service>();
 		http.reset(new HttpServer());
-		if (localAddress.length() > 0) http->config.address = localAddress.toStdString();
+		if (localAddress.isNotEmpty()) http->config.address = localAddress.toStdString();
 		http->config.port = port;
 		http->io_service = ioService;
 

--- a/SimpleWebSocketServer.cpp
+++ b/SimpleWebSocketServer.cpp
@@ -26,8 +26,9 @@ SimpleWebSocketServerBase::~SimpleWebSocketServerBase()
 	stopThread(2000);
 }
 
-void SimpleWebSocketServerBase::start(int _port, const String& _wsSuffix)
+void SimpleWebSocketServerBase::start(int _port, const String& _wsSuffix, const String& _localAddress)
 {
+	localAddress = _localAddress;
 	port = _port;
 	wsSuffix = _wsSuffix;
 	startThread();
@@ -180,6 +181,7 @@ void SimpleWebSocketServer::initServer()
 	{
 		ioService = std::make_shared<asio::io_service>();
 		http.reset(new HttpServer());
+		if (localAddress.length() > 0) http->config.address = localAddress.toStdString();
 		http->config.port = port;
 		http->io_service = ioService;
 

--- a/SimpleWebSocketServer.h
+++ b/SimpleWebSocketServer.h
@@ -30,7 +30,7 @@ public:
 	virtual ~SimpleWebSocketServerBase();
 
 	juce::File rootPath;
-	juce::String localAddress = "";
+	juce::String localAddress;
 	int port;
 	juce::String wsSuffix;
 	bool isConnected;

--- a/SimpleWebSocketServer.h
+++ b/SimpleWebSocketServer.h
@@ -30,13 +30,14 @@ public:
 	virtual ~SimpleWebSocketServerBase();
 
 	juce::File rootPath;
+	juce::String localAddress = "";
 	int port;
 	juce::String wsSuffix;
 	bool isConnected;
 
 	juce::CriticalSection serverLock;
 
-	void start(int port = 8080, const juce::String& wsSuffix = "");
+	void start(int port = 8080, const juce::String& wsSuffix = "", const juce::String& _localAddress = "");
 
 	virtual void send(const juce::String& message) {}
 	virtual void send(const char* data, int numData) {}


### PR DESCRIPTION
In the http->start() function, the default behaviour when there is no http->config.address specified is to create an IPv6 endpoint..

There was no way to specify an address in the library for the user so I added one. 

The way it has been implemented should be leave the behaviour unchanged for any existing code.