### PR TITLE
Websocket server can have multiple HTTP request handlers

### DIFF
--- a/SimpleWebSocketServer.cpp
+++ b/SimpleWebSocketServer.cpp
@@ -70,7 +70,29 @@ void SimpleWebSocketServerBase::run()
 	initServer();
 }
 
+void SimpleWebSocketServerBase::addHTTPRequestHandler(RequestHandler* newHandler) 
+{
+	if (handler == nullptr)
+	{
+		handler = newHandler;
+	}
+	else
+	{
+		handlers.add(newHandler); 
+	}
+}
 
+void SimpleWebSocketServerBase::removeHTTPRequestHandler(RequestHandler* handlerToRemove) 
+{
+	if (handler == handlerToRemove)
+	{
+		handler = nullptr;
+	}
+	else
+	{
+		handlers.removeFirstMatchingValue(handlerToRemove); 
+	}
+}
 
 //SIMPLE
 
@@ -354,9 +376,16 @@ void SimpleWebSocketServer::httpDefaultCallback(std::shared_ptr<HttpServer::Resp
 {
 	if (handler != nullptr)
 	{
-
 		bool handled = handler->handleHTTPRequest(response, request);
 		if (handled) return;
+	}
+
+	for (auto& secondaryHandler : handlers)
+	{
+		if (secondaryHandler->handleHTTPRequest(response, request))
+		{
+			return;
+		}
 	}
 
 	if (rootPath.exists() && rootPath.isDirectory())
@@ -604,6 +633,14 @@ void SecureWebSocketServer::httpDefaultCallback(std::shared_ptr<HttpsServer::Res
 	{
 		bool handled = handler->handleHTTPSRequest(response, request);
 		if (handled) return;
+	}
+
+	for (auto& secondaryHandler : handlers)
+	{
+		if (secondaryHandler->handleHTTPSRequest(response, request))
+		{
+			return;
+		}
 	}
 
 	if (rootPath.exists() && rootPath.isDirectory())

--- a/SimpleWebSocketServer.h
+++ b/SimpleWebSocketServer.h
@@ -93,6 +93,7 @@ public:
 #endif
 	};
 
+	[[deprecated("The handler should be deleted soon, please use the handlers array instead.")]]
 	RequestHandler* handler;
 
 	/// @brief Add a new http request handler. Incoming requests will be forwarded to handlers in the order they've been added

--- a/SimpleWebSocketServer.h
+++ b/SimpleWebSocketServer.h
@@ -95,6 +95,13 @@ public:
 
 	RequestHandler* handler;
 
+	/// @brief Add a new http request handler. Incoming requests will be forwarded to handlers in the order they've been added
+	/// until one successfully handles it.
+	void addHTTPRequestHandler(RequestHandler* newHandler);
+	void removeHTTPRequestHandler(RequestHandler* handlerToRemove);
+
+protected:
+	juce::Array<RequestHandler*> handlers;
 };
 
 


### PR DESCRIPTION
I've kept the old handler member for now bc I think a lot of users use it directly. I've added a deprecation attribute so that direct access cause a compilation warning to help user move to the new api, but i can remove it if necessary