### PR TITLE
Route OPTIONS through default_resource so RequestHandlers can answer CORS preflight

### DIFF
--- a/SimpleWebSocketServer.cpp
+++ b/SimpleWebSocketServer.cpp
@@ -221,6 +221,7 @@ void SimpleWebSocketServer::initServer()
 		http->default_resource["PUT"] = httpCallbackFunc;
 		http->default_resource["DELETE"] = httpCallbackFunc;
 		http->default_resource["PATCH"] = httpCallbackFunc;
+		http->default_resource["OPTIONS"] = httpCallbackFunc;
 		http->on_upgrade = std::bind(&SimpleWebSocketServer::onHTTPUpgrade, this, std::placeholders::_1, std::placeholders::_2);
 
 		// WebSocket init
@@ -570,6 +571,7 @@ void SecureWebSocketServer::initServer()
 		http->io_service = ioService;
 
 		http->default_resource["GET"] = std::bind(&SecureWebSocketServer::httpDefaultCallback, this, std::placeholders::_1, std::placeholders::_2);
+		http->default_resource["OPTIONS"] = std::bind(&SecureWebSocketServer::httpDefaultCallback, this, std::placeholders::_1, std::placeholders::_2);
 		http->on_upgrade = std::bind(&SecureWebSocketServer::onHTTPUpgrade, this, std::placeholders::_1, std::placeholders::_2);
 
 		// WebSocket init


### PR DESCRIPTION
## Problem

`SimpleWebSocketServer::initServer` registers `default_resource` for `GET`/`POST`/`PUT`/`DELETE`/`PATCH`, but not `OPTIONS`. Browser-based clients that issue a CORS preflight (`OPTIONS /path` with `Access-Control-Request-Method`) hit Simple-Web-Server's parser, which finds no matching resource and silently drops the connection. From the client side this surfaces as `curl: (52) Empty reply from server`. Any `RequestHandler` registered via `addHTTPRequestHandler` never sees the request, so consumers can't answer preflight even if they want to.

The same gap existed in `SecureWebSocketServer::initServer`, which only registered `GET` — so on HTTPS endpoints, `POST`/`PUT`/`DELETE`/`PATCH`/`OPTIONS` all dropped. This PR adds `OPTIONS` routing to both variants; fully normalizing the HTTPS surface to match HTTP is left as a follow-up to keep this PR focused on the OPTIONS bug.

## Fix

Two-line change. Adds `default_resource["OPTIONS"]` in both `SimpleWebSocketServer::initServer` and `SecureWebSocketServer::initServer`, routed to the same `httpDefaultCallback` path as the other methods. `RequestHandler` implementations can then choose to answer preflight (typical CORS shape: 204 + `Access-Control-Allow-*` headers) or return false and let preflight fall through to the unmatched-path handler.

## Backward compatibility

Adding a method to `default_resource` only makes it *routable*. Existing handlers see no behaviour change for `GET`/`POST`/etc. Consumers that don't currently handle `OPTIONS` in their `RequestHandler::handleHTTPRequest` will see it return `false` (the default) and Simple-Web-Server will fall through to the same path it already uses for unmatched requests. No existing call site is affected.

## Verification

Before, with a `RequestHandler` registered that wants to answer OPTIONS:

\`\`\`
$ curl -v -X OPTIONS http://localhost:7400/api/anything
> OPTIONS /api/anything HTTP/1.1
* Empty reply from server
curl: (52) Empty reply from server
\`\`\`

After (with the same `RequestHandler` returning 204 + CORS headers):

\`\`\`
$ curl -v -X OPTIONS http://localhost:7400/api/anything
< HTTP/1.1 204 No Content
< Access-Control-Allow-Methods: POST, GET, OPTIONS
< Access-Control-Allow-Origin: *
\`\`\`

Field-tested in an MCP server consumer ([WFS-DIY](https://github.com/pob31/WFS-DIY)) where browser-based MCP clients need preflight to succeed before they can issue the JSON-RPC POST. GET/POST/PUT/DELETE/PATCH on the same endpoint behave identically to before the patch.

## Side note (not in this PR)

While reading the code I noticed `SecureWebSocketServer::initServer` only registers `GET` (i.e. POST/PUT/DELETE/PATCH on HTTPS were silently dropped before this patch as well). Happy to send a follow-up PR normalizing the HTTPS surface to match the plain-HTTP one if that's wanted — wanted to keep this PR focused on the OPTIONS preflight bug.