### PR TITLE
Forward error code to users in connection error callbacks

### DIFF
--- a/SimpleWebSocketClient.cpp
+++ b/SimpleWebSocketClient.cpp
@@ -56,10 +56,10 @@ void SimpleWebSocketClientBase::handleConnectionClosedCallback(int status, const
 	this->webSocketListeners.call(&Listener::connectionClosed, status, reason);
 }
 
-void SimpleWebSocketClientBase::handleErrorCallback(const String& message)
+void SimpleWebSocketClientBase::handleErrorCallback(int status, const String& message)
 {
 	this->isConnected = false;
-	if (!this->isClosing) this->webSocketListeners.call(&Listener::connectionError, message);
+	if (!this->isClosing) this->webSocketListeners.call(&Listener::connectionError, status, message);
 }
 
 
@@ -142,7 +142,7 @@ void SimpleWebSocketClient::onConnectionCloseCallback(std::shared_ptr<WsClient::
 
 void SimpleWebSocketClient::onErrorCallback(std::shared_ptr<WsClient::Connection>, const SimpleWeb::error_code& ec)
 {
-	handleErrorCallback(ec.message());
+	handleErrorCallback(ec.value(), ec.message());
 }
 
 
@@ -217,6 +217,6 @@ void SecureWebSocketClient::onConnectionCloseCallback(std::shared_ptr<WssClient:
 
 void SecureWebSocketClient::onErrorCallback(std::shared_ptr<WssClient::Connection>, const SimpleWeb::error_code& ec)
 {
-	handleErrorCallback(ec.message());
+	handleErrorCallback(ec.value(), ec.message());
 }
 #endif

--- a/SimpleWebSocketClient.h
+++ b/SimpleWebSocketClient.h
@@ -44,7 +44,7 @@ public:
 
 	void handleNewConnectionCallback();
 	void handleConnectionClosedCallback(int status, const juce::String& reason);
-	void handleErrorCallback(const juce::String& message);
+	void handleErrorCallback(int status, const juce::String& message);
 
 	class Listener
 	{
@@ -54,7 +54,7 @@ public:
 		virtual void messageReceived(const juce::String& message) {}
 		virtual void dataReceived(const juce::MemoryBlock& data) {}
 		virtual void connectionClosed(int status, const juce::String& reason) {}
-		virtual void connectionError(const juce::String& message) {}
+		virtual void connectionError(int status, const juce::String& message) {}
 	};
 
 	juce::ListenerList<Listener> webSocketListeners;

--- a/SimpleWebSocketServer.cpp
+++ b/SimpleWebSocketServer.cpp
@@ -362,7 +362,7 @@ void SimpleWebSocketServer::onErrorCallback(std::shared_ptr<WsServer::Connection
 {
 	String id = getConnectionString(connection);
 	connectionMap.remove(id);
-	webSocketListeners.call(&Listener::connectionError, id, ec.message());
+	webSocketListeners.call(&Listener::connectionError, id, ec.value(), ec.message());
 }
 
 void SimpleWebSocketServer::httpStartCallback(unsigned short _port)
@@ -654,7 +654,7 @@ void SecureWebSocketServer::onErrorCallback(std::shared_ptr<WssServer::Connectio
 {
 	String id = getConnectionString(connection);
 	connectionMap.remove(id);
-	webSocketListeners.call(&Listener::connectionError, id, ec.message());
+	webSocketListeners.call(&Listener::connectionError, id, ec.value(), ec.message());
 }
 
 void SecureWebSocketServer::httpStartCallback(unsigned short _port)

--- a/SimpleWebSocketServer.h
+++ b/SimpleWebSocketServer.h
@@ -75,7 +75,7 @@ public:
 		virtual void messageReceived(const juce::String& id, const juce::String& message) {}
 		virtual void dataReceived(const juce::String& id, const juce::MemoryBlock& data) {}
 		virtual void connectionClosed(const juce::String& id, int status, const juce::String& reason) {}
-		virtual void connectionError(const juce::String& id, const juce::String& message) {}
+		virtual void connectionError(const juce::String& id, int status, const juce::String& message) {}
 	};
 
 


### PR DESCRIPTION
Allows users to react accordingly based on error code

⚠️ Breaking changes, downstream projects will need to update their listeners' signatures